### PR TITLE
fix fb login issues, close #263

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -58,8 +58,9 @@ module.exports = passport => {
               return User.create({
                 name: profile._json.name,
                 email: profile._json.email,
-                role: user,
-                password: hash
+                role: 'user',
+                password: hash,
+                isValid: true
               }).then(user => {
                 return done(null, user)
               }).catch(err => {

--- a/routes/hbs/authRoute.js
+++ b/routes/hbs/authRoute.js
@@ -7,8 +7,8 @@ router.get('/facebook',
 )
 router.get('/facebook/callback',
   passport.authenticate('facebook', {
-    successRedirect: '/',
-    failureRedirect: '/accounts/signin',
+    successRedirect: 'https://ajashop.co/',
+    failureRedirect: 'https://ajashop.co/accounts/signin',
   })
 )
 


### PR DESCRIPTION
完成功能如下：

1. 使用者成功使用 FB 登入後，導回 https://ajashop.co 
2. 使用者用 FB 登入時，不需要另外寄送 email 認證，isValid 將回直接變成 true